### PR TITLE
Fixing mac torch issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-torch = "^1.0.2"
+torch = "^2.2.0"
 numpy = "^1.26.3"
 pandas = "^2.2.0"
 


### PR DESCRIPTION
Updating the pytorch version to ^2.2.0 makes the torch install work for macs (just need to make sure you are using python 11 instead of python 12 as well)