### PR TITLE
table data retrieved as gzip; addtiional columns now present from DB

### DIFF
--- a/yeastdnnexplorer/interface/AbstractRecordsAndFilesAPI.py
+++ b/yeastdnnexplorer/interface/AbstractRecordsAndFilesAPI.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 import tarfile
@@ -101,8 +102,9 @@ class AbstractRecordsAndFilesAPI(AbstractAPI):
                     export_url, headers=self.header, params=self.params
                 ) as response:
                     response.raise_for_status()
-                    text = await response.text()
-                    records_df = pd.read_csv(BytesIO(text.encode()))
+                    content = await response.content.read()
+                    with gzip.GzipFile(fileobj=BytesIO(content)) as f:
+                        records_df = pd.read_csv(f)
 
                     if not retrieve_files:
                         return callback(records_df, None, self.cache, **kwargs)


### PR DESCRIPTION
@ejiawustl  -- The database had a breaking change.

You will need to use this commit in order to use the database. Best to just do the code review and then merge to `dev`.

The change has to do with how the table records are being passed from the database. Previously, the endpoint said it was being sent as a gzip data stream, but was actually coming in plain text.

With this change, the data transfer should be slightly better, but more importantly, some additional columns will be included in the 'metadata', eg the regulator locus tag and symbol in the Binding and PromoterSetSig, for instance.