### PR TITLE
fixing the csv sniffer auto detection of delimiters

### DIFF
--- a/yeastdnnexplorer/interface/AbstractRecordsAndFilesAPI.py
+++ b/yeastdnnexplorer/interface/AbstractRecordsAndFilesAPI.py
@@ -72,7 +72,6 @@ class AbstractRecordsAndFilesAPI(AbstractAPI):
         :type sample_size: int
         :return: The delimiter of the CSV file.
         :rtype: str
-
         :raises FileNotFoundError: If the file does not exist.
         :raises gzip.BadGzipFile: If the file is not a valid gzip file.
         :raises _csv.Error: If the CSV sniffer cannot determine the delimiter.


### PR DESCRIPTION
to detect the delimiter automatically, a sample of the file is read in. If that sample truncates a line, it sometimes causes the sniffer to fail.

Code has been added to detect the last instance of a newline character, and remove any text after that.