### PR TITLE
adding `condition` to the valid promotersetsig filters

### DIFF
--- a/yeastdnnexplorer/interface/PromoterSetSigAPI.py
+++ b/yeastdnnexplorer/interface/PromoterSetSigAPI.py
@@ -36,6 +36,7 @@ class PromoterSetSigAPI(AbstractRecordsAndFilesAPI):
                 "workflow",
                 "data_usable",
                 "aggregated",
+                "condition",
             ],
         )
 


### PR DESCRIPTION
This adds "condition" to the valid promotersetsig filters. Setting this to anything other than 'unknown' essentially selects only harbison_chip records.

The harbison_chip conditions are listed here:

https://github.com/cmatKhan/yeastregulatorydb/blob/5c7625c881d669ad80795cfaca0568fb09ab3278/yeastregulatorydb/regulatory_data/models/Binding.py#L17

We more or less should be using only YPD