### PR TITLE
Fixing sequential pipeline

### DIFF
--- a/yeastdnnexplorer/__main__.py
+++ b/yeastdnnexplorer/__main__.py
@@ -271,18 +271,18 @@ def find_interactors_workflow(args: argparse.Namespace) -> None:
 
         # Build the formula using these predictors
         response_variable = f"{args.response_tf}_LRR"
-        predictor_variable = re.sub(r"_rep\\d+", "", args.response_tf)
+        # predictor_variable = re.sub(r"_rep\\d+", "", args.response_tf)
 
         # Ensure the main effect of the perturbed TF is included
         formula_terms = significant_predictors_all.copy()
-        if predictor_variable not in formula_terms:
-            formula_terms.insert(0, predictor_variable)
+        # if predictor_variable not in formula_terms:
+        #     formula_terms.insert(0, predictor_variable)
 
         # Build the formula string
         formula = f"{response_variable} ~ {' + '.join(formula_terms)}"
 
         # Add '-1' to the formula if drop_intercept is True
-        formula += " - 1"
+        # formula += " - 1"
 
         # Run get_significant_predictors with the custom formula
         sequential_lasso_res = get_significant_predictors(
@@ -292,7 +292,7 @@ def find_interactors_workflow(args: argparse.Namespace) -> None:
             predictors_df,
             ci_percentile=args.top_ci_percentile,
             n_bootstraps=args.n_bootstraps,
-            add_max_lrb=True,
+            add_max_lrb=False,
             quantile_threshold=args.data_quantile,
             formula=formula,  # Pass the formula via kwargs
         )

--- a/yeastdnnexplorer/__main__.py
+++ b/yeastdnnexplorer/__main__.py
@@ -271,18 +271,12 @@ def find_interactors_workflow(args: argparse.Namespace) -> None:
 
         # Build the formula using these predictors
         response_variable = f"{args.response_tf}_LRR"
-        # predictor_variable = re.sub(r"_rep\\d+", "", args.response_tf)
 
         # Ensure the main effect of the perturbed TF is included
         formula_terms = significant_predictors_all.copy()
-        # if predictor_variable not in formula_terms:
-        #     formula_terms.insert(0, predictor_variable)
 
         # Build the formula string
         formula = f"{response_variable} ~ {' + '.join(formula_terms)}"
-
-        # Add '-1' to the formula if drop_intercept is True
-        # formula += " - 1"
 
         # Run get_significant_predictors with the custom formula
         sequential_lasso_res = get_significant_predictors(

--- a/yeastdnnexplorer/ml_models/lasso_modeling.py
+++ b/yeastdnnexplorer/ml_models/lasso_modeling.py
@@ -372,8 +372,9 @@ def bootstrap_stratified_cv_modeling(
             X_resampled.loc[:, response_tf].squeeze(), Y_resampled.squeeze()
         )
 
-        # this is the second part of the code for the edge case in which during sequential modeling we do not find the main effect
-        # to be significant in the first place, therefore we must ignore it for modeling purposes
+        # this is the second part of the code for the edge case in which during
+        # sequential modeling we do not find the main effect to be significant
+        # in the first place, therefore we must ignore it for modeling purposes
         ignore_main_effects = kwargs.get("ignore_main_effect", False)
         if ignore_main_effects:
             X_resampled = X_resampled.drop([response_tf], axis=1)
@@ -391,7 +392,8 @@ def bootstrap_stratified_cv_modeling(
     # Convert coefficients list to a DataFrame with column names from X
     bootstrap_coefs_df = pd.DataFrame(
         bootstrap_coefs,
-        # this is the fourth part of the code that handles the edge case where you drop the main effect if needed
+        # this is the fourth part of the code that handles the edge case where you drop
+        # the main effect if needed
         columns=(
             X.drop(columns=[response_tf]).columns if ignore_main_effects else X.columns
         ),
@@ -592,8 +594,9 @@ def get_significant_predictors(
             "Must be one of ['lassocv_ols', 'bootstrap_lassocv']"
         )
 
-    # this is the first part of the code that checks for the edge case in which the main effect isn't in the formula
-    # if it is not there, then we must add it when generating the modeling data, and then ignore it for the actual modeling which
+    # this is the first part of the code that checks for the edge case in which the main
+    # effect isn't in the formula if it is not there, then we must add it when
+    # generating the modeling data, and then ignore it for the actual modeling which
     # is done by the other part of the code in this method and in bootstrap_cv_modeling
     formula = kwargs.get("formula", None)
     if formula:


### PR DESCRIPTION
This fixes some errors in the sequential pipeline modeling. Essentially, when performing the sequential pipeline runs previously, the main effect and max_lrb term were being added into the second round of bootstrapping regardless of whether or not they survived the initial lasso bootstrapping. This has been removed to reflect the correct process of the sequential pipeline in which the main effect and max_lrb terms are included in the second round of lasso bootstrapping only if they were found to be significant after the first round. 

Following this change, four additional lines of codes were added to check for edge cases to avoid errors.